### PR TITLE
Compatibility with StarBEAST and other packages

### DIFF
--- a/src/beast/inference/PathSampler.java
+++ b/src/beast/inference/PathSampler.java
@@ -270,29 +270,24 @@ public class PathSampler extends beast.core.Runnable {
 		}
 		CompoundDistribution d = (CompoundDistribution) posterior;
 		List<Distribution> list = d.pDistributions.get();
-		if (list.size() > 3 || list.size() < 2) {
-            throw new Exception("Expected one prior, one likelihood and an optional multispecies coalescent distribution.");
+		if (list.size() < 2) {
+            throw new Exception("Expected one likelihood and at least one prior distribution.");
 		}
 
-		Distribution prior = null;
-		Distribution msc = null;
-		Distribution likelihood = null;
-        for (Distribution subDist: list) {
-            final String distID = subDist.getID().toLowerCase();
-            if (distID.startsWith("prior")) prior = subDist;
-            if (distID.startsWith("speciescoalescent")) msc = subDist;
-            if (distID.startsWith("likelihood")) likelihood = subDist;
+		Distribution[] pDists = new Distribution[list.size()];
+		int nextPriorIndex = 1;
+        for (Distribution pDist: list) {
+            final String distID = pDist.getID().toLowerCase();
+            if (distID.startsWith("likelihood")) {
+                if (pDists[0] == null) pDists[0] = pDist; 
+                else throw new Exception("Expected only one likelihood distribution.");
+            } else {
+                pDists[nextPriorIndex] = pDist;
+                nextPriorIndex++;
+            }
         }
 
-        if (msc == null && list.size() == 3)
-            throw new Exception("Expected one prior, one likelihood and an optional multispecies coalescent distribution.");
-
-        if (prior == null)
-            throw new IllegalArgumentException("No prior distribution found in posterior.");
-        if (likelihood == null)
-            throw new IllegalArgumentException("No likelihood distribution found in posterior.");
-
-        return likelihood;
+        return pDists[0];
 	}
 
 	String getCommand(String sStepDir, int iStep) {

--- a/src/beast/inference/PathSampler.java
+++ b/src/beast/inference/PathSampler.java
@@ -270,18 +270,29 @@ public class PathSampler extends beast.core.Runnable {
 		}
 		CompoundDistribution d = (CompoundDistribution) posterior;
 		List<Distribution> list = d.pDistributions.get();
-		if (list.size() != 2) {
-			throw new Exception("Expected posterior with only likelihood and prior as distributions");
+		if (list.size() > 3 || list.size() < 2) {
+            throw new Exception("Expected one prior, one likelihood and an optional multispecies coalescent distribution.");
 		}
-		if (list.get(0).getID().toLowerCase().startsWith("likelihood")) {
-			return list.get(0);
-		} else {
-			if (list.get(1).getID().toLowerCase().startsWith("likelihood")) {
-				return list.get(1);
-			} else {
-				throw new Exception("Expected posterior with only likelihood and prior as IDs");
-			}
-		}
+
+		Distribution prior = null;
+		Distribution msc = null;
+		Distribution likelihood = null;
+        for (Distribution subDist: list) {
+            final String distID = subDist.getID().toLowerCase();
+            if (distID.startsWith("prior")) prior = subDist;
+            if (distID.startsWith("speciescoalescent")) msc = subDist;
+            if (distID.startsWith("likelihood")) likelihood = subDist;
+        }
+
+        if (msc == null && list.size() == 3)
+            throw new Exception("Expected one prior, one likelihood and an optional multispecies coalescent distribution.");
+
+        if (prior == null)
+            throw new IllegalArgumentException("No prior distribution found in posterior.");
+        if (likelihood == null)
+            throw new IllegalArgumentException("No likelihood distribution found in posterior.");
+
+        return likelihood;
 	}
 
 	String getCommand(String sStepDir, int iStep) {

--- a/src/beast/inference/PathSamplingStep.java
+++ b/src/beast/inference/PathSamplingStep.java
@@ -139,13 +139,11 @@ public class PathSamplingStep extends MCMC {
      * main MCMC loop *
      */
     protected void doLoop() {
-    	
         double logPriorProb = prior.calculateLogP();
         double logMSC = (msc == null) ? 0.0 : msc.calculateLogP();
         double logLikelihood = likelihood.calculateLogP();
         oldLogLikelihood = logPriorProb + logMSC + (logLikelihood * beta);
-    	
-    	
+
         for (int iSample = -burnIn; iSample <= chainLength; iSample++) {
             final int currentState = iSample;
 
@@ -197,7 +195,7 @@ public class PathSamplingStep extends MCMC {
 
                 posterior.calculateLogP();
                 logPriorProb = prior.getArrayValue();
-                logMSC = (msc == null) ? 0.0 : msc.calculateLogP();
+                logMSC = (msc == null) ? 0.0 : msc.getArrayValue();
                 logLikelihood = likelihood.getArrayValue();
 
                 newLogLikelihood = logPriorProb + logMSC + (logLikelihood * beta); 

--- a/src/beast/inference/PathSamplingStep.java
+++ b/src/beast/inference/PathSamplingStep.java
@@ -132,7 +132,7 @@ public class PathSamplingStep extends MCMC {
      * main MCMC loop *
      */
     protected void doLoop() {
-        oldLogLikelihood += pDists[0].calculateLogP() * beta; // likelihood
+        oldLogLikelihood = pDists[0].calculateLogP() * beta; // likelihood
         for (int i = 1; i < pDists.length; i++) //priors
             oldLogLikelihood += pDists[i].calculateLogP();
 
@@ -186,7 +186,7 @@ public class PathSamplingStep extends MCMC {
                 state.checkCalculationNodesDirtiness();
 
                 posterior.calculateLogP();
-                newLogLikelihood += pDists[0].getArrayValue() * beta; // likelihood
+                newLogLikelihood = pDists[0].getArrayValue() * beta; // likelihood
                 for (int i = 1; i < pDists.length; i++) //priors
                     newLogLikelihood += pDists[i].getArrayValue();
 

--- a/version.xml
+++ b/version.xml
@@ -1,4 +1,4 @@
-<addon name='MODEL_SELECTION' version='1.3.1'>
+<addon name='MODEL_SELECTION' version='1.3.2'>
 	<depends on='beast2' atleast='2.4.0'/>
 	<depends on='BEASTLabs' atleast='1.5.0'/>
     <addonapp description="Path sampler"


### PR DESCRIPTION
Enables model-selection to work when multiple prior distributions are specified, as is the case with *BEAST and StarBEAST2.
